### PR TITLE
BRGD-235 Cache Expiration Topic

### DIFF
--- a/cicd/stacks/brighid-infrastructure/template.yml
+++ b/cicd/stacks/brighid-infrastructure/template.yml
@@ -76,6 +76,9 @@ Resources:
   ResponseTopic:
     Type: AWS::SNS::Topic
 
+  CacheExpirationTopic:
+    Type: AWS::SNS::Topic
+
   ServiceRegistry:
     Type: AWS::ServiceDiscovery::PrivateDnsNamespace
     Properties:
@@ -177,6 +180,12 @@ Outputs:
     Description: ARN of the Response Topic
     Export:
       Name: !Sub ${AWS::StackName}:ResponseTopicArn
+
+  CacheExpirationTopic:
+    Value: !Ref CacheExpirationTopic
+    Description: ARN of the Cache Expiration Topic
+    Export:
+      Name: !Sub ${AWS::StackName}:CacheExpirationTopic
 
   ServiceRegistry:
     Value: !Ref ServiceRegistry


### PR DESCRIPTION
Adds a cache expiration topic so applications can be notified when to expire a token from the cache.