### PR TITLE
Add Cognito Identity Pool

### DIFF
--- a/cicd/stacks/brighid-infrastructure/template.yml
+++ b/cicd/stacks/brighid-infrastructure/template.yml
@@ -166,6 +166,13 @@ Resources:
       CloudFrontOriginAccessIdentityConfig:
         Comment: Origin access identity for Brighid Static Assets
 
+  CognitoIdentityPool:
+    Type: AWS::Cognito::IdentityPool
+    Properties:
+      AllowUnauthenticatedIdentities: false
+      DeveloperProviderName: !Ref BaseDomainName
+      IdentityPoolName: !Ref BaseDomainName
+
   SSLCertificate:
     Type: Custom::Certificate
     Properties:


### PR DESCRIPTION
Add a Cognito Identity Pool, which will eventually allow for AWS Credential exchange with Brighid Identity.